### PR TITLE
Finish most/least_accurate_team as well as helper accurate_team

### DIFF
--- a/lib/game_team.rb
+++ b/lib/game_team.rb
@@ -1,10 +1,12 @@
 class GameTeam
-  attr_reader :game_info, :game_id, :team_id, :won
+  attr_reader :game_info, :game_id, :team_id, :won, :shots, :goals 
 
   def initialize(game_info)
     @game_info = game_info
     @game_id = game_info[:game_id]
     @team_id = game_info[:team_id]
     @won = game_info[:won]
+    @shots = game_info[:shots]
+    @goals = game_info[:goals]
   end
 end

--- a/modules/season_helper.rb
+++ b/modules/season_helper.rb
@@ -68,4 +68,44 @@ module SeasonHelper
     end
     reg_wins
   end
+
+  def game_shots
+    @game_teams.map do |game_team|
+      game_team.game_info[:shots]
+    end
+  end
+
+  def game_goals
+    @game_teams.map do |game_team|
+      game_team.game_info[:goals]
+    end
+  end
+
+  def season_games(season_id)
+    all_games_by_season(season_id).group_by do |game|
+      game.season
+    end
+  end
+
+  def accurate_team(games)
+    team_data = Hash.new
+    games.each do |game|
+      away_team = game.away_team_id
+      home_team = game.home_team_id
+
+      away_team_game = @game_teams.find do |game_team|
+        game.game_id == game_team.game_id && away_team == game_team.team_id
+      end
+      home_team_game = @game_teams.find do |game_team|
+        game.game_id == game_team.game_id && home_team == game_team.team_id
+      end
+      team_data[home_team] ||= {shots: 0, goals: 0}
+      team_data[away_team] ||= {shots: 0, goals: 0}
+      team_data[home_team][:shots] += home_team_game.shots.to_i
+      team_data[home_team][:goals] += home_team_game.goals.to_i
+      team_data[away_team][:shots] += away_team_game.shots.to_i
+      team_data[away_team][:goals] += away_team_game.goals.to_i
+    end
+    team_data
+  end
 end

--- a/modules/season_stats.rb
+++ b/modules/season_stats.rb
@@ -1,3 +1,4 @@
+require 'pry'
 module SeasonStatistics
   def biggest_bust(season_id)
     reg_wins = reg_wins_by_team(season_id)
@@ -14,14 +15,27 @@ module SeasonStatistics
 
   def biggest_surprise(season_id)
     reg_wins = reg_wins_by_team(season_id)
-
     post_wins = post_wins_by_team(season_id)
-
     reg_wins = post_reg_difference(reg_wins, post_wins)
-
     most_improved = reg_wins.max_by do |win|
       win[1]
     end
     @teams[most_improved[0].to_sym].team_name
+  end
+
+  def most_accurate_team(season_id)
+    games = all_games_by_season(season_id)
+    team_data = accurate_team(games).max_by do |game|
+      game[1][:goals]/game[1][:shots].to_f
+    end
+    @teams[team_data[0].to_sym].team_name
+  end
+
+  def least_accurate_team(season_id)
+    games = all_games_by_season(season_id)
+    team_data = accurate_team(games).min_by do |game|
+      game[1][:goals]/game[1][:shots].to_f
+    end
+    @teams[team_data[0].to_sym].team_name
   end
 end

--- a/test/season_stats_test.rb
+++ b/test/season_stats_test.rb
@@ -21,4 +21,13 @@ class SeasonStatisticsTest < MiniTest::Test
     assert_equal "Lightning", @stat_tracker.biggest_surprise('20172018')
   end
 
+  def test_most_accurate_team
+    assert_equal "Bruins", @stat_tracker.most_accurate_team("20122013")
+    assert_equal "Lightning", @stat_tracker.most_accurate_team("20172018")
+  end
+
+  def test_least_accurate_team
+    assert_equal "Rangers", @stat_tracker.least_accurate_team("20122013")
+    assert_equal "Bruins", @stat_tracker.least_accurate_team("20172018")
+  end
 end


### PR DESCRIPTION
This commit takes care of most/least_accurate_teams, which uses the helper methods all_games_by_season and accurate_team. The helper method accurate_teams needs to be shortened but other than that, all the tests pass :')